### PR TITLE
Segment intersection fix

### DIFF
--- a/include/cg/operations/has_intersection/segment_segment.h
+++ b/include/cg/operations/has_intersection/segment_segment.h
@@ -11,8 +11,6 @@ namespace cg
    {
       if (a[0] == a[1])
          return contains(b, a[0]);
-      if (b[0] == b[1])
-         return contains(a, b[0]);
 
       orientation_t ab[2];
       for (size_t l = 0; l != 2; ++l)

--- a/include/cg/operations/has_intersection/segment_segment.h
+++ b/include/cg/operations/has_intersection/segment_segment.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cg/primitives/segment.h>
-
+#include <cg/operations/contains/segment_point.h>
 #include <cg/operations/orientation.h>
 
 namespace cg
@@ -9,6 +9,11 @@ namespace cg
    template<class Scalar>
    bool has_intersection(segment_2t<Scalar> const & a, segment_2t<Scalar> const & b)
    {
+      if (a[0] == a[1])
+         return contains(b, a[0]);
+      if (b[0] == b[1])
+         return contains(a, b[0]);
+
       orientation_t ab[2];
       for (size_t l = 0; l != 2; ++l)
          ab[l] = orientation(a[0], a[1], b[l]);
@@ -18,7 +23,7 @@ namespace cg
             || (min(a) <= b[1] && max(a) >= b[1])
             || (min(b) <= a[0] && max(b) >= a[0])
             || (min(b) <= a[1] && max(b) >= a[1]);
-   
+
       if (ab[0] == ab[1])
          return false;
 

--- a/tests/has_intersection.cpp
+++ b/tests/has_intersection.cpp
@@ -35,6 +35,14 @@ TEST(has_intersection, segment_segment)
    s1 = { {0, 0}, {0, 0} };
    s2 = { {-1, -1}, {1, -1} };
    EXPECT_FALSE(cg::has_intersection(s1, s2));
+
+   s1 = { {0, 0}, {0, 0} };
+   s2 = { {0, 0}, {0, 0} };
+   EXPECT_TRUE(cg::has_intersection(s1, s2));
+
+   s1 = { {0, 0}, {0, 0} };
+   s2 = { {1, 0}, {1, 0} };
+   EXPECT_FALSE(cg::has_intersection(s1, s2));
 }
 
 TEST(has_intersection, triangle_segment)

--- a/tests/has_intersection.cpp
+++ b/tests/has_intersection.cpp
@@ -31,6 +31,10 @@ TEST(has_intersection, segment_segment)
    point_2 a1(0.5, 0), a2(0.5, 0), a3(0, 0), a4(1, 0);
    segment_2 s1(a1, a2), s2(a3, a4);
    EXPECT_TRUE(cg::has_intersection(s1, s2));
+
+   s1 = { {0, 0}, {0, 0} };
+   s2 = { {-1, -1}, {1, -1} };
+   EXPECT_FALSE(cg::has_intersection(s1, s2));
 }
 
 TEST(has_intersection, triangle_segment)


### PR DESCRIPTION
There is a bug in segment intersection when one of the segments is a single point (see new tests)
