### PR TITLE
Orientation bugfix

### DIFF
--- a/include/cg/operations/orientation.h
+++ b/include/cg/operations/orientation.h
@@ -59,9 +59,6 @@ namespace cg
          if (res.upper() < 0)
             return CG_RIGHT;
 
-         if (res.upper() == res.lower())
-            return CG_COLLINEAR;
-
          return boost::none;
       }
    };


### PR DESCRIPTION
Кажется upper == lower означает, что интервал выродился в точку, а не равенство интервала нулю.

Кто-нибудь, подтвердите что это и правда так :)
